### PR TITLE
Add flag for headers

### DIFF
--- a/cmd/kaf/consume.go
+++ b/cmd/kaf/consume.go
@@ -382,13 +382,8 @@ func protoDecode(reg *proto.DescriptorRegistry, b []byte, _type string) ([]byte,
 	} else {
 		err := dynamicMessage.Unmarshal(b)
 		if err != nil {
-			// if there is an error, it might be a Confluent message, try parsing without headers
-			bTrimmed := discardConfluentHeader(b)
-			trimmedErr := dynamicMessage.Unmarshal(bTrimmed)
-			// if trimming doesn't help just return original error
-			if trimmedErr != nil {
-				return nil, err
-			}
+			err = fmt.Errorf("retry with --confluent-header if invalid proto, it may be a confluent formatted message: %w", err)
+			return nil, err
 		}
 	}
 

--- a/cmd/kaf/consume.go
+++ b/cmd/kaf/consume.go
@@ -28,6 +28,7 @@ var (
 	groupCommitFlag bool
 	raw             bool
 	follow          bool
+	confluentHeader bool
 	tail            int32
 	schemaCache     *avro.SchemaCache
 	keyfmt          *prettyjson.Formatter
@@ -55,6 +56,7 @@ func init() {
 	consumeCmd.Flags().StringSliceVar(&protoFiles, "proto-include", []string{}, "Path to proto files")
 	consumeCmd.Flags().StringSliceVar(&protoExclude, "proto-exclude", []string{}, "Proto exclusions (path prefixes)")
 	consumeCmd.Flags().BoolVar(&decodeMsgPack, "decode-msgpack", false, "Enable deserializing msgpack")
+	consumeCmd.Flags().BoolVar(&confluentHeader, "confluent-header", false, "Force deserialization of messages with confluent headers (use if header detection fails)")
 	consumeCmd.Flags().StringVar(&protoType, "proto-type", "", "Fully qualified name of the proto message type. Example: com.test.SampleMessage")
 	consumeCmd.Flags().StringVar(&keyProtoType, "key-proto-type", "", "Fully qualified name of the proto key type. Example: com.test.SampleMessage")
 	consumeCmd.Flags().Int32SliceVarP(&flagPartitions, "partitions", "p", []int32{}, "Partitions to consume from")
@@ -370,21 +372,30 @@ func protoDecode(reg *proto.DescriptorRegistry, b []byte, _type string) ([]byte,
 		return b, nil
 	}
 
-	err := dynamicMessage.Unmarshal(b)
-	if err != nil {
-		// if there is an error, it might be a Confluent message, try parsing without headers
+	// user requested confluent aware decoding
+	if confluentHeader {
 		bTrimmed := discardConfluentHeader(b)
-		trimmedErr := dynamicMessage.Unmarshal(bTrimmed)
-		// if trimming doesn't help just return original error
-		if trimmedErr != nil {
+		err := dynamicMessage.Unmarshal(bTrimmed)
+		if err != nil {
 			return nil, err
+		}
+	} else {
+		err := dynamicMessage.Unmarshal(b)
+		if err != nil {
+			// if there is an error, it might be a Confluent message, try parsing without headers
+			bTrimmed := discardConfluentHeader(b)
+			trimmedErr := dynamicMessage.Unmarshal(bTrimmed)
+			// if trimming doesn't help just return original error
+			if trimmedErr != nil {
+				return nil, err
+			}
 		}
 	}
 
 	var m jsonpb.Marshaler
 	var w bytes.Buffer
 
-	err = m.Marshal(&w, dynamicMessage)
+	err := m.Marshal(&w, dynamicMessage)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Add explicit flag to force confluent schema mode. 

We encountered a case where the headers were accidentally being parsed by the proto schema resulting in a constant value of 0 for that field. Since our "smart" logic depends on the proto parsing failing, it would attempt to correctly parse it as a confluent formatted message.

With the flag, messages where we are not detecting Confluent headers correctly can still be decoded by adding the `--confluent-header` flag