### PR TITLE
Add Confluent header to find

### DIFF
--- a/cmd/kaf/query.go
+++ b/cmd/kaf/query.go
@@ -18,6 +18,7 @@ func init() {
 	queryCmd.Flags().StringVarP(&keyFlag, "key", "k", "", "Key to search for")
 	queryCmd.Flags().StringSliceVar(&protoFiles, "proto-include", []string{}, "Path to proto files")
 	queryCmd.Flags().StringSliceVar(&protoExclude, "proto-exclude", []string{}, "Proto exclusions (path prefixes)")
+	queryCmd.Flags().BoolVar(&confluentHeader, "confluent-header", false, "Force deserialization of messages with confluent headers (use if header detection fails)")
 	queryCmd.Flags().StringVar(&protoType, "proto-type", "", "Fully qualified name of the proto message type. Example: com.test.SampleMessage")
 	queryCmd.Flags().StringVar(&keyProtoType, "key-proto-type", "", "Fully qualified name of the proto key type. Example: com.test.SampleMessage")
 


### PR DESCRIPTION
Support confluent header option for `query` subcommand to find specific messages