### PR TITLE
Kaf Producer: Add Confluent Schema support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -64,6 +64,8 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 // indirect
+	github.com/riferrei/srclient v0.5.4 // indirect
+	github.com/santhosh-tekuri/jsonschema/v5 v5.0.0 // indirect
 	github.com/segmentio/kafka-go v0.4.34 // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -249,6 +249,7 @@ github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
+github.com/linkedin/goavro/v2 v2.9.7/go.mod h1:UgQUb2N/pmueQYH9bfqFioWxzYCZXSfF8Jw03O5sjqA=
 github.com/linkedin/goavro/v2 v2.12.0 h1:rIQQSj8jdAUlKQh6DttK8wCRv4t4QO09g1C4aBWXslg=
 github.com/linkedin/goavro/v2 v2.12.0/go.mod h1:KXx+erlq+RPlGSPmLF7xGo6SAbh8sCQ53x064+ioxhk=
 github.com/magiconair/properties v1.8.6 h1:5ibWZ6iY0NctNGWo87LalDlEZ6R41TqbbDamhfG/Qzo=
@@ -313,6 +314,8 @@ github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 h1:N/ElC8H3+5XpJzTSTfLsJV/mx9Q9g7kxmchpfZyxgzM=
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
+github.com/riferrei/srclient v0.5.4 h1:dfwyR5u23QF7beuVl2WemUY2KXh5+Sc4DHKyPXBNYuc=
+github.com/riferrei/srclient v0.5.4/go.mod h1:vbkLmWcgYa7JgfPvuy/+K8fTS0p1bApqadxrxi/S1MI=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
@@ -320,6 +323,8 @@ github.com/rogpeppe/go-internal v1.6.1 h1:/FiVV8dS/e+YqF2JvO3yXRFbBLTIuSDkuC7aBO
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/santhosh-tekuri/jsonschema/v5 v5.0.0 h1:TToq11gyfNlrMFZiYujSekIsPd9AmsA2Bj/iv+s4JHE=
+github.com/santhosh-tekuri/jsonschema/v5 v5.0.0/go.mod h1:FKdcjfQW6rpZSnxxUvEA5H/cDPdvJ/SZJQLWWXWGrZ0=
 github.com/segmentio/kafka-go v0.4.34 h1:Dm6YlLMiVSiwwav20KY0AoY63s661FXevwJ3CVHUERo=
 github.com/segmentio/kafka-go v0.4.34/go.mod h1:GAjxBQJdQMB5zfNA21AhpaqOB2Mu+w3De4ni3Gbm8y0=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=

--- a/pkg/proto/schema.go
+++ b/pkg/proto/schema.go
@@ -1,0 +1,54 @@
+package proto
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	"github.com/riferrei/srclient"
+)
+
+type SchemaClient struct {
+	client srclient.ISchemaRegistryClient
+}
+
+func NewSchemaClient(url string, key string, secret string) *SchemaClient {
+	schemaClient := srclient.CreateSchemaRegistryClient(url)
+	schemaClient.SetCredentials(key, secret)
+	return &SchemaClient{client: schemaClient}
+}
+
+// HeaderForTopic returns a Confluent Wire Format header that must be pre-pended to messages
+// for Confluent to be able to decode messages using Schema Registry
+// https://docs.confluent.io/platform/current/schema-registry/serdes-develop/index.html#wire-format
+// This is made available while we are in the midst of transitioning
+// to having the Confluent header on all of our messages Once all
+// messages use the header, it should be simpler to just use the
+// producer interceptor (NewConfluentProducerInterceptor) above rather
+// than doing this every time we produce to kafka
+func (sc SchemaClient) HeaderForTopic(topic string) ([]byte, error) {
+	// Default Confluent naming strategy appends -value to schemas for message body
+	// https://docs.confluent.io/platform/current/schema-registry/serdes-develop/index.html#subject-name-strategy
+	schema, err := sc.client.GetLatestSchema(fmt.Sprintf("%s-value", topic))
+	if err != nil {
+		return nil, fmt.Errorf("unable to get topic schema %s: %w", topic, err)
+	}
+	if schema == nil {
+		return nil, fmt.Errorf("nil schema for topic %s", topic)
+	}
+	return confluentHeader(schema.ID()), nil
+}
+
+// confluent header format: https://docs.confluent.io/platform/current/schema-registry/serdes-develop/index.html#wire-format
+func confluentHeader(schemaID int) []byte {
+	schemaIDBytes := make([]byte, 4)
+	binary.BigEndian.PutUint32(schemaIDBytes, uint32(schemaID))
+
+	var header []byte
+	// Magic Byte, always 0
+	header = append(header, byte(0))
+	// Schema ID
+	header = append(header, schemaIDBytes...)
+	// Protobuf message index. We assume 0 and only upload one message type for each topic
+	header = append(header, byte(0))
+	return header
+}


### PR DESCRIPTION
Add Confluent header support to produce command.

There exists a schema registry library that is used in `pkg/avro/schema.go` to support adding Confluent Headers to avro messages. It is `github.com/Landoop/schema-registry`, however, it looks like this package is no longer maintained so let's just import the package we use in `backend`

Sidenote: As we keep adding stuff to `kaf`, I wonder if we want to just invest some time into it and reorganize the code a bit. Might be an interesting hackathon project. Or see if we can make any of these additions suitable to merge upstream (not sure how open they are to contributions)

[ch89426] 

Tested by doing the following:

Consume on topic to see that we are sending well formed messages:
```kaf --cluster nonprod-ue1-confluent-01 consume dev-shield-stream-batch-v1  --proto-include ~/git/shared-protobuf/kafka/shield/ --proto-type shield.StreamBatch --confluent-header```

```kaf --cluster nonprod-ue1-confluent-01 produce dev-shield-stream-batch-v1 --key 10 --proto-include ~/git/shared-protobuf/kafka/shield/ --proto-type shield.StreamBatch --confluent-header --schema-registry-key $SRKEY --schema-registry-secret $SRSECRET --schema-registry-url https://psrc-knmwm.us-east-2.aws.confluent.cloud```

message payload
`{"batch_i_d":10, "stream_i_d":12, "name":"name1", "description":"description1", "agent_i_d":2, "is_active": true}`

Output of consume command:
```
{
  "agentID": 2,
  "batchID": 10,
  "description": "description1",
  "isActive": true,
  "name": "name1",
  "streamID": 12
}
```