### PR TITLE
Trim header bytes

### DIFF
--- a/cmd/kaf/consume.go
+++ b/cmd/kaf/consume.go
@@ -28,7 +28,6 @@ var (
 	groupCommitFlag        bool
 	raw                    bool
 	follow                 bool
-	confluentHeader        bool
 	trimKeyHeaderBytes     uint32
 	trimMessageHeaderBytes uint32
 	tail                   int32

--- a/cmd/kaf/kaf.go
+++ b/cmd/kaf/kaf.go
@@ -254,6 +254,17 @@ func getSchemaCache() (cache *avro.SchemaCache) {
 	return cache
 }
 
+func getSchemaRegistryClient() (registry proto.SchemaClient) {
+	var schemaClient proto.SchemaClient
+	if schemaRegistryType == "confluent" {
+		if schemaRegistryUrl == "" || schemaRegistryKey == "" || schemaRegistrySecret == "" {
+			errorExit("schema-registry-url, schema-registry-key, and schema-registry-secret are required for confluent schema registry")
+		}
+		schemaClient = proto.NewConfluentSchemaClient(schemaRegistryUrl, schemaRegistryKey, schemaRegistrySecret)
+	}
+	return schemaClient
+}
+
 func errorExit(format string, a ...interface{}) {
 	fmt.Fprintf(errWriter, format+"\n", a...)
 	os.Exit(1)

--- a/cmd/kaf/query.go
+++ b/cmd/kaf/query.go
@@ -18,7 +18,6 @@ func init() {
 	queryCmd.Flags().StringVarP(&keyFlag, "key", "k", "", "Key to search for")
 	queryCmd.Flags().StringSliceVar(&protoFiles, "proto-include", []string{}, "Path to proto files")
 	queryCmd.Flags().StringSliceVar(&protoExclude, "proto-exclude", []string{}, "Proto exclusions (path prefixes)")
-	queryCmd.Flags().BoolVar(&confluentHeader, "confluent-header", false, "Force deserialization of messages with confluent headers (use if header detection fails)")
 	queryCmd.Flags().StringVar(&protoType, "proto-type", "", "Fully qualified name of the proto message type. Example: com.test.SampleMessage")
 	queryCmd.Flags().StringVar(&keyProtoType, "key-proto-type", "", "Fully qualified name of the proto key type. Example: com.test.SampleMessage")
 
@@ -73,7 +72,7 @@ var queryCmd = &cobra.Command{
 						var keyTextRaw string
 						var valueTextRaw string
 						if protoType != "" {
-							d, err := protoDecode(reg, msg.Value, protoType)
+							d, err := protoDecode(reg, msg.Value, protoType, trimMessageHeaderBytes)
 							if err != nil {
 								fmt.Println("Failed proto decode")
 							}
@@ -83,7 +82,7 @@ var queryCmd = &cobra.Command{
 						}
 
 						if keyProtoType != "" {
-							d, err := protoDecode(reg, msg.Key, keyProtoType)
+							d, err := protoDecode(reg, msg.Key, keyProtoType, trimKeyHeaderBytes)
 							if err != nil {
 								fmt.Println("Failed proto decode")
 							}

--- a/cmd/kaf/query.go
+++ b/cmd/kaf/query.go
@@ -72,7 +72,7 @@ var queryCmd = &cobra.Command{
 						var keyTextRaw string
 						var valueTextRaw string
 						if protoType != "" {
-							d, err := protoDecode(reg, msg.Value, protoType, trimMessageHeaderBytes)
+							d, err := protoDecode(reg, msg.Value, protoType)
 							if err != nil {
 								fmt.Println("Failed proto decode")
 							}
@@ -82,7 +82,7 @@ var queryCmd = &cobra.Command{
 						}
 
 						if keyProtoType != "" {
-							d, err := protoDecode(reg, msg.Key, keyProtoType, trimKeyHeaderBytes)
+							d, err := protoDecode(reg, msg.Key, keyProtoType)
 							if err != nil {
 								fmt.Println("Failed proto decode")
 							}

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/mattn/go-colorable v0.1.13
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/orlangure/gnomock v0.21.1
+	github.com/riferrei/srclient v0.5.4
 	github.com/spf13/cobra v1.5.0
 	github.com/stretchr/testify v1.8.0
 	github.com/vmihailenco/msgpack/v5 v5.3.5
@@ -64,7 +65,6 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 // indirect
-	github.com/riferrei/srclient v0.5.4 // indirect
 	github.com/santhosh-tekuri/jsonschema/v5 v5.0.0 // indirect
 	github.com/segmentio/kafka-go v0.4.34 // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect


### PR DESCRIPTION
Some Kafka producers (debezium) and schema registries prepend header bytes to messages and keys, preventing this tool from outputing the appropriate format. By trimming arbitrary bytes from the start of both, the message can be read correctly.

Replaces the `--confluent-header` flag in order to be provider-agnostic (e.g. we can also trim the bytes debezium prepends).

For context, debezium prepends 5 bytes to both key and message. Using the Confluent schema registry for protocol buffers prepends 6 bytes to the message.