### PR TITLE
Align query output with consume

### DIFF
--- a/cmd/kaf/query.go
+++ b/cmd/kaf/query.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"sync"
 
@@ -104,8 +105,11 @@ var queryCmd = &cobra.Command{
 						}
 
 						if match {
-							fmt.Printf("Key: %v\n", keyTextRaw)
-							fmt.Printf("Value: %v\n", valueTextRaw)
+							var stderr bytes.Buffer
+							dataToDisplay := formatMessage(msg, []byte(valueTextRaw), []byte(keyTextRaw), &stderr)
+							stderr.WriteTo(errWriter)
+							_, _ = colorableOut.Write(dataToDisplay)
+							fmt.Fprintln(outWriter)
 						}
 
 						if msg.Offset == pc.HighWaterMarkOffset()-1 {


### PR DESCRIPTION
Use same formatting function as in `consume` command. Was getting annoyed that the query command had such basic output compared to consume. Especially it is useful to be able to see offset + timestamp. But also the formatting is nice

Mirrors the code from: https://github.com/Hinge/kaf/blob/master/cmd/kaf/consume.go#L330